### PR TITLE
Export IconComponent type in the index.tsx file

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,10 @@ const FILE_BANNER = `/**
  * All rights reserved.
  */
 
+import * as React from 'react';
+
+export type IconComponent = React.SFC<{ className?: string }>;
+
 `;
 
 function log(message, type = LOG_NEWLINE) {


### PR DESCRIPTION
## Description

Purpose of this PR is to expose generic `IconComponent` type that describes icon components exported in the `index.tsx` file.

This is useful for example in case you want to create a utility function that returns an icon:

```
import * as Icon, { IconComponent } from './Icons';

const getCheckboxIcon = (
  isChecked: boolean,
  isIndeterminate: boolean,
): IconComponent => {
  if (isIndeterminate) {
    return Icon.CheckboxMisc;
  }

  if (isChecked) {
    return Icon.CheckboxOn;
  }

  return Icon.CheckboxOff;
};
```