### PR TITLE
Pass all props

### DIFF
--- a/src/babel/pbfied.js
+++ b/src/babel/pbfied.js
@@ -9,23 +9,10 @@ const pbfiedPlugin = ({ types: t }) => {
     name: "pbfiedPlugin",
     visitor: {
       VariableDeclarator(path) {
-        const className = t.objectPattern([
-          t.objectProperty(
-            t.identifier("className"),
-            t.identifier("className"),
-            false,
-            true
-          )
-        ]);
-
-        const classNameTypeAnnotation = t.objectTypeProperty(
-          t.identifier("className"),
-          t.stringTypeAnnotation()
-        );
-        classNameTypeAnnotation.optional = true;
+        const className = t.identifier("props");
 
         className.typeAnnotation = t.typeAnnotation(
-          t.objectTypeAnnotation([classNameTypeAnnotation])
+          t.genericTypeAnnotation(t.identifier("React.SVGProps<SVGSVGElement>"))
         );
 
         path.node.init.params = [className];


### PR DESCRIPTION
Also in scenario where there is only one `Path` let's remove the `fill` since we want to use the css fallback.

close #15 

input:
```xml
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M8 12c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4zm0-2c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z" fill="#ACB6BF"/></svg>
```

output
```ts
/**
 * Copyright (c) 2019-present, ProductBoard, Inc.
 * All rights reserved.
 */

import React from "react";
import cx from "classnames";
import styles from "./Icon.styles";

const BulletLevel2 = (props: React.SVGProps<SVGSVGElement>) => (
  <svg
    viewBox="0 0 16 16"
    {...props}
    className={cx(props.className, styles.icon, "pb-icon")}
  >
    <path d="M8 12c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4zm0-2c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z" />
  </svg>
);

export default BulletLevel2;
```