### PR TITLE
fix: handling of empty suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ You will get React Component like this:
  * All rights reserved.
  */
 
-import React from "react";
-import cx from "classnames";
-import styles from "./Icon.styles";
+import React from 'react'
+import cx from 'classnames'
+import styles from './Icon.styles'
 
 const Feature = ({ className }: { className: string }) => (
-  <svg viewBox="0 0 16 16" className={cx(className, styles.icon, "pb-icon")}>
+  <svg viewBox="0 0 16 16" className={cx(className, styles.icon, 'pb-icon')}>
     <path d="M15 0c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H1c-.6 0-1-.4-1-1V1c0-.6.4-1 1-1h14zm-1 14V2H2v12h12zM4 7h8v2H4V7zm0-3h8v2H4V4zm0 6h4v2H4v-2z" />
   </svg>
-);
+)
 
-export default Feature;
+export default Feature
 ```
 
 ## Configuration
@@ -65,8 +65,8 @@ Exported binary `svg-componentify` has this possible configuration (via argument
 
 - `--icon-path` (required) Where to look for SVG icons
 - `--export-path` (required) Where to export optimized icon React components
-- `--extension` (defaults to `react`)
-- `--suffix` (defaults to `tsx`)
+- `--extension` (defaults to `tsx`)
+- `--suffix` (defaults to `react`)
 - `--only-staged` (defaults to `false`) Transform only staged svg icons files
 - `--all` (defaults to `false`) Process all files
 - `-v`, `--version` to print actual version of the tool

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,10 @@ export type IconComponent = React.FC<{ className?: string, style?: React.CSSProp
 
 `;
 
+function generateSuffix(suffix) {
+  return suffix === '' ? '' : `.${suffix}`
+}
+
 function log(message, type = LOG_NEWLINE) {
   let modifier = "";
   switch (type) {
@@ -136,7 +140,7 @@ async function generateComponent(iconName, options) {
   log(`Processing "${iconName}"...`);
 
   const componentName = getComponentNameFromFileName(iconName);
-  const componentPath = `${exportPath}/${componentName}.${suffix}.${extension}`;
+  const componentPath = `${exportPath}/${componentName}${generateSuffix(suffix)}.${extension}`;
   const svgPath = `${iconPath}/${iconName}`;
 
   // check if the import path exists, if not the file has been removed (from git history) so we want to delete it
@@ -213,7 +217,7 @@ function createIndexFile(icons, options) {
   for (icon of icons) {
     name = getComponentNameFromFileName(icon);
 
-    content += `export { default as ${name} } from './${name}.${suffix}';\n`;
+    content += `export { default as ${name} } from './${name}${generateSuffix(suffix)}';\n`;
   }
 
   fs.writeFileSync(`${exportPath}/index.tsx`, content);
@@ -259,13 +263,14 @@ async function getStagedIcons(options) {
 async function getXORIcons(options) {
   const { iconPath, exportPath, suffix, extension } = options;
 
+
   // get icons we have
   const icons = fs
     .readdirSync(iconPath)
     .filter(isSvg)
     .map(iconName => {
       const componentName = getComponentNameFromFileName(iconName);
-      return `${componentName}.${suffix}.${extension}`;
+      return `${componentName}${generateSuffix(suffix)}.${extension}`;
     });
 
   // get generated icons we have


### PR DESCRIPTION
This properly handles `suffix`, right when suffix was empty string it created component like: `Component..tsx` instead of `Component.tsx`.